### PR TITLE
Added "scaml" helper to use scaml templates easily

### DIFF
--- a/src/main/g8/src/main/scala/$servlet_name$.scala
+++ b/src/main/g8/src/main/scala/$servlet_name$.scala
@@ -1,8 +1,7 @@
 import org.scalatra._
 import java.net.URL
-import scalate.ScalateSupport
 
-class $servlet_name$ extends ScalatraFilter with ScalateSupport {
+class $servlet_name$ extends ScalatraFilter with ScalatraAction {
   
   get("/") {
     <html>
@@ -13,19 +12,19 @@ class $servlet_name$ extends ScalatraFilter with ScalateSupport {
     </html>
   }
 
+  get("/ping") {
+    contentType = "text/plain"
+    scaml("pong")
+  }
+
   notFound {
-    // If no route matches, then try to render a Scaml template
-    val templateBase = requestPath match {
-      case s if s.endsWith("/") => s + "index"
-      case s => s
-    }
-    val templatePath = "/WEB-INF/scalate/templates/" + templateBase + ".scaml"
+    val templatePath = viewTemplateFor("scaml", requestPath)
     servletContext.getResource(templatePath) match {
-      case url: URL => 
+      case url: URL =>
         contentType = "text/html"
         templateEngine.layout(templatePath)
-      case _ => 
+      case _ =>
         filterChain.doFilter(request, response)
-    } 
+    }
   }
 }

--- a/src/main/g8/src/main/scala/ScalatraAction.scala
+++ b/src/main/g8/src/main/scala/ScalatraAction.scala
@@ -1,0 +1,16 @@
+import org.scalatra._
+import scalate.ScalateSupport
+
+trait ScalatraAction extends ScalateSupport {
+  protected def scaml(name:String) = 
+    templateEngine.layout(viewTemplateFor("scaml", name))
+
+  protected def viewTemplateFor(ext:String, name:String) = {
+    val base = name match {
+      case s if s.endsWith("/") => s + "index"
+      case s => s
+    }
+    "/WEB-INF/scalate/templates/%s.%s".format(base, ext)
+  }
+}
+

--- a/src/main/g8/src/main/webapp/WEB-INF/scalate/templates/pong.scaml
+++ b/src/main/g8/src/main/webapp/WEB-INF/scalate/templates/pong.scaml
@@ -1,0 +1,2 @@
+- attributes("layout") = ""  // Disabling layouts
+Pong


### PR DESCRIPTION
ScalatraAction trait provides "scaml" method to use scaml view templates easily.
And also added a ping/pong example for it.

before

<pre>
templateEngine.layout("/WEB-INF/scalate/templates/foo.scaml")
</pre>

after

<pre>
scaml("foo")
</pre>
