### PR TITLE
Updated dependencies to sbt 0.11.3 and related xsbt-web-plugin 0.2.11.1

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.11.2
+sbt.version=0.11.3

--- a/src/main/g8/project/build.properties
+++ b/src/main/g8/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.11.2
+sbt.version=0.11.3

--- a/src/main/g8/project/plugins.sbt
+++ b/src/main/g8/project/plugins.sbt
@@ -1,1 +1,1 @@
-libraryDependencies <+= sbtVersion(v => "com.github.siasia" %% "xsbt-web-plugin" % (v+"-0.2.10"))
+libraryDependencies <+= sbtVersion(v => "com.github.siasia" %% "xsbt-web-plugin" % (v+"-0.2.11.1"))


### PR DESCRIPTION
Sbt 0.11.3 and xsbt-web-plugin 0.2.11.1 were released recently and the group-id change in sbt (now org.scala-sbt) prevented a new sbt-launcher from correctly loading a project set to use 0.11.2.

I tried to g8 ($ g8 utaal/scalatra-sbt.g8 -b sbt-0.11.3) from my repository and it worked fine; as I am not very familiar with how g8 and sbt work you may want to doublecheck my changes.

Hope this helps.
Andrea
