### PR TITLE
Updated dependencies to sbt 0.11.3 and related xsbt-web-plugin 0.2.11.1.

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.11.2
+sbt.version=0.11.3

--- a/src/main/g8/project/build.properties
+++ b/src/main/g8/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.11.2
+sbt.version=0.11.3

--- a/src/main/g8/project/plugins.sbt
+++ b/src/main/g8/project/plugins.sbt
@@ -1,1 +1,1 @@
-libraryDependencies <+= sbtVersion(v => "com.github.siasia" %% "xsbt-web-plugin" % (v+"-0.2.10"))
+libraryDependencies <+= sbtVersion(v => "com.github.siasia" %% "xsbt-web-plugin" % (v+"-0.2.11.1"))


### PR DESCRIPTION
Same as #6, this time for scalatra 2.1

($ g8 utaal/scalatra-sbt.g8 -b develop-sbt-0.11.3)
