### PR TITLE
Pointing sbt link at the new sbt website.

### DIFF
--- a/src/main/g8/README.md
+++ b/src/main/g8/README.md
@@ -1,4 +1,4 @@
-1. Launch [SBT](http://code.google.com/p/simple-build-tool).
+1. Launch [SBT](http://www.scala-sbt.org/).
 
 ```
 ./sbt


### PR DESCRIPTION
I find the google site to be old, unmaintained, and confusing, the new website seems better.
