### PR TITLE
Bump to 2.1.1

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -11,9 +11,9 @@ seq(webSettings :_*)
 classpathTypes ~= (_ + "orbit")
 
 libraryDependencies ++= Seq(
-  "org.scalatra" % "scalatra" % "2.1.0",
-  "org.scalatra" % "scalatra-scalate" % "2.1.0",
-  "org.scalatra" % "scalatra-specs2" % "2.1.0" % "test",
+  "org.scalatra" % "scalatra" % "2.1.1",
+  "org.scalatra" % "scalatra-scalate" % "2.1.1",
+  "org.scalatra" % "scalatra-specs2" % "2.1.1" % "test",
   "ch.qos.logback" % "logback-classic" % "1.0.6" % "runtime",
   "org.eclipse.jetty" % "jetty-webapp" % "8.1.7.v20120910" % "container",
   "org.eclipse.jetty.orbit" % "javax.servlet" % "3.0.0.v201112011016" % "container;provided;test" artifacts (Artifact("javax.servlet", "jar", "jar"))


### PR DESCRIPTION
The g8 template was sitting at 2.1.0, I guess it should be moved up to 2.1.1 now?
