### PR TITLE
A couple of typos break the "First Project" tutorial

### DIFF
--- a/src/main/g8/src/main/scala/ScalatraBootstrap.scala
+++ b/src/main/g8/src/main/scala/ScalatraBootstrap.scala
@@ -7,7 +7,7 @@ class ScalatraBootstrap extends LifeCycle {
     try {
       context.mount(new $servlet_name$, "/*")
     } catch {
-      case t: Throwable => t.printStacktrace()
+      case t: Throwable => t.printStackTrace()
     }
   }
 }

--- a/src/main/g8/src/main/webapp/WEB-INF/views/hello-scalate.jade
+++ b/src/main/g8/src/main/webapp/WEB-INF/views/hello-scalate.jade
@@ -1,4 +1,4 @@
 - attributes("title") = "Scalatra: a tiny, Sinatra-like web framework for Scala"
 - attributes("headline") = "Welcome to Scalatra"
 
-p= Hello, Scalate!
+p= "Hello, Scalate!"


### PR DESCRIPTION
Looks like I decided to run the "First Project" tutorial during your refactor. :frowning:

Fortunately the typos were easy to spot from the compile errors. :smiley:
