### PR TITLE
Small fix to the defaultTemplatePath of the template.

### DIFF
--- a/src/main/g8/src/main/scala/$package$/$name__Camel$Stack.scala
+++ b/src/main/g8/src/main/scala/$package$/$name__Camel$Stack.scala
@@ -10,11 +10,11 @@ import collection.mutable
 trait $name;format="Camel"$Stack extends ScalatraServlet with ScalateSupport {
 
   /* wire up the precompiled templates */
-  override protected def defaultTemplatePath: List[String] = List("/templates/views")
+  override protected def defaultTemplatePath: List[String] = List("/WEB-INF/templates/views")
   override protected def createTemplateEngine(config: ConfigT) = {
     val engine = super.createTemplateEngine(config)
     engine.layoutStrategy = new DefaultLayoutStrategy(engine,
-      TemplateEngine.templateTypes.map("/templates/layouts/default." + _): _*)
+      TemplateEngine.templateTypes.map("/WEB-INF/templates/layouts/default." + _): _*)
     engine.packagePrefix = "templates"
     engine
   }


### PR DESCRIPTION
Dear Scalatra developers,

After reading a lot of source code trying to make my Scalatra app run on Tomcat,
I noticed that the defaultTemplatePath suggested in the template was not right. As you
can see in [1], it should start with /WEB-INF.

I'm not sure whether the same is true for DefaultLayoutStrategy, but I believe so. Could you confirm that?

[1] https://github.com/scalatra/scalatra/blob/develop/scalate/src/main/scala/org/scalatra/scalate/ScalateSupport.scala#L169-L170

Best regards,
Gabriel Assis Bezerra.

P.S.: If you need any reference about me, I'm the guy who has been in touch with Ross Baker in #scalatra@freenode.net in the last few days.
