### PR TITLE
Bumped jetty-webapp dependency

### DIFF
--- a/src/main/g8/project/build.scala
+++ b/src/main/g8/project/build.scala
@@ -26,7 +26,7 @@ object $name;format="Camel"$Build extends Build {
         "org.scalatra" %% "scalatra-scalate" % ScalatraVersion,
         "org.scalatra" %% "scalatra-specs2" % ScalatraVersion % "test",
         "ch.qos.logback" % "logback-classic" % "1.0.6" % "runtime",
-        "org.eclipse.jetty" % "jetty-webapp" % "8.1.8.v20121106" % "container",
+        "org.eclipse.jetty" % "jetty-webapp" % "8.1.14.v20131031" % "container",
         "org.eclipse.jetty.orbit" % "javax.servlet" % "3.0.0.v201112011016" % "container;provided;test" artifacts (Artifact("javax.servlet", "jar", "jar"))
       ),
       scalateTemplateConfig in Compile <<= (sourceDirectory in Compile){ base =>


### PR DESCRIPTION
Was running into random-ish `WARN log handle failed` errors with
response code 0 when running via `container:start`

Bumping to the latest 8.1.x version of `jetty-webapp` has fixed that
for me.
