### PR TITLE
Update plugins.sbt

### DIFF
--- a/src/main/g8/project/plugins.sbt
+++ b/src/main/g8/project/plugins.sbt
@@ -1,3 +1,3 @@
 addSbtPlugin("com.mojolly.scalate" % "xsbt-scalate-generator" % "0.4.2")
 
-addSbtPlugin("org.scalatra.sbt" % "scalatra-sbt" % "0.3.2")
+addSbtPlugin("org.scalatra.sbt" % "scalatra-sbt" % "0.3.5")


### PR DESCRIPTION
0.3.2 tries to download 'org.eclipse.jetty.orbit#javax.servlet;3.0.0.v201112011016!javax.servlet.orbit'

updating to use 0.3.5 clears up the issue
