### PR TITLE
Changed execution method of sbt command written in README

### DIFF
--- a/src/main/g8/README.md
+++ b/src/main/g8/README.md
@@ -4,7 +4,7 @@
 
 ```sh
 \$ cd $name;format="snake"$
-\$ ./sbt
+\$ sbt
 > jetty:start
 > browse
 ```


### PR DESCRIPTION
Since the sbt command is no longer included in the project
template, the description to execute the sbt command in the
project directory is incorrect.