### PR TITLE
Update to sbt-scalatra 1.0.2 to get jetty 9.4.8

### DIFF
--- a/src/main/g8/project/plugins.sbt
+++ b/src/main/g8/project/plugins.sbt
@@ -1,2 +1,2 @@
 addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % "1.3.13")
-addSbtPlugin("org.scalatra.sbt" % "sbt-scalatra" % "1.0.1")
+addSbtPlugin("org.scalatra.sbt" % "sbt-scalatra" % "1.0.2")


### PR DESCRIPTION
via xsbt-web-plugin 4.0.2

Root fix: https://github.com/eclipse/jetty.project/issues/1692

Stream: 
  https://github.com/earldouglas/xsbt-web-plugin/issues/361
  https://github.com/scalatra/sbt-scalatra/issues/55

Note that this cannot be merged until https://github.com/scalatra/sbt-scalatra/commit/fbaa9c732ffa8a5b1185f0f13dcbfd4e5df74e27 is released, presumably in sbt-scalatra 1.0.2