### PR TITLE
fixed format of created directory

### DIFF
--- a/src/main/g8/README.md
+++ b/src/main/g8/README.md
@@ -3,7 +3,7 @@
 ## Build & Run ##
 
 ```sh
-\$ cd $name;format="snake"$
+\$ cd $name;format="norm"$
 \$ sbt
 > jetty:start
 > browse


### PR DESCRIPTION
The directory name of the project written in the README is wrong.

It is written to be generated by snake case,
but it is actually created in kebab case.