### PR TITLE
xsbt-web-plugin 4.2.4 -> sbt-war 5.0.0-M2

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 $ sbt new scalatra/scalatra.g8
 $ cd <name-of-app>
 $ sbt
-> Jetty/start
+> webappStart
 ```
 
 - Open [http://localhost:8080/](http://localhost:8080/) in your browser.
@@ -38,7 +38,7 @@ $ sbt
 > exit
 $ cd target/sbt-test/scalatra-g8/scripted
 $ sbt
-> Jetty/start
+> webappStart
 > browse # starts browser for you, or manually open http://localhost:8080 to verify
 ```
 

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -11,13 +11,9 @@ lazy val hello = (project in file("."))
       "org.scalatra" %% "scalatra-jakarta" % ScalatraVersion,
       "org.scalatra" %% "scalatra-scalatest-jakarta" % ScalatraVersion % "test",
       "ch.qos.logback" % "logback-classic" % "1.5.6" % "runtime",
-      "org.eclipse.jetty.ee10" % "jetty-ee10-webapp" % "$jetty_version$" % "container",
       "jakarta.servlet" % "jakarta.servlet-api" % "6.0.0" % "provided"
     ),
   )
 
 enablePlugins(SbtTwirl)
-enablePlugins(JettyPlugin)
-
-Jetty / containerLibs := Seq("org.eclipse.jetty.ee10" % "jetty-ee10-runner" % "$jetty_version$" intransitive())
-Jetty / containerMain := "org.eclipse.jetty.ee10.runner.Runner"
+enablePlugins(SbtWar)

--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -7,5 +7,5 @@ scala_version=3.3.3
 sbt_version=1.10.0
 scalatra_version=3.1.0
 twirl_version=2.0.6
-xsbt_web_plugin_version=4.2.4
+sbt_war_version=5.0.0-M2
 jetty_version=12.0.10

--- a/src/main/g8/project/plugins.sbt
+++ b/src/main/g8/project/plugins.sbt
@@ -1,2 +1,2 @@
 addSbtPlugin("org.playframework.twirl" % "sbt-twirl" % "$twirl_version$")
-addSbtPlugin("com.earldouglas" % "xsbt-web-plugin" % "$xsbt_web_plugin_version$")
+addSbtPlugin("com.earldouglas" % "sbt-war" % "$sbt_war_version$")


### PR DESCRIPTION
We might want to wait for the non-milestone 5.0.0 release, in which case this PR can serve as a placeholder.

sbt-war 5 uses `com.heroku:webapp-runner`, which uses Tomcat (currently version 10.1.28, which [targets the 6.0 servlet spec](https://tomcat.apache.org/whichversion.html)); would we want to use the Eclipse Jetty runner instead?